### PR TITLE
Updated hapi to version 10.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "code": "1.5.0",
-    "hapi": "8.8.1",
+    "hapi": "10.2.1",
     "lab": "6.1.0"
   },
   "scripts": {


### PR DESCRIPTION
:rocket:

hapi just published version 10.2.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 154 commits (ahead by 154, behind by 0).
- [fc2f49d](https://github.com/hapijs/hapi/commit/fc2f49de5895963af494d5fa3a3f7010ffb294b5): 10.2.1
- [e157ba6](https://github.com/hapijs/hapi/commit/e157ba6181d9088d49b6212c941683186366697f): Document adding connection from plugin. Closes #2754
- [5c6cef2](https://github.com/hapijs/hapi/commit/5c6cef2f08dfca013e689109a2bff8b0fd0138e5): Fix connectionless plugins. Closes #2817
- [990aad4](https://github.com/hapijs/hapi/commit/990aad4d3b723a9b2794f04a63122090d10f9c1c): Merge branch 'master' of github.com:hapijs/hapi
- [0f7af21](https://github.com/hapijs/hapi/commit/0f7af21e92d0d105a9534d25aa6180df63eef9e1): Adjust test timing
- [43be3c0](https://github.com/hapijs/hapi/commit/43be3c0f8ce40b709a2307550b4eb39d9d8a9b1f): Merge pull request #2816 from devinivy/empty-payload-docs
- [9ed674c](https://github.com/hapijs/hapi/commit/9ed674c1a16a4800431b532d08b52d1a04cdc046): Fix joi empty payload example in docs.
- [019732d](https://github.com/hapijs/hapi/commit/019732d5a2fb023ff988e6a051928bdddd90bc78): Small optimization
- [a063aba](https://github.com/hapijs/hapi/commit/a063abaa1ac5576a01c3a0b5de07a782a9d2712a): Fix single connection bug. Closes #2813
- [2f23298](https://github.com/hapijs/hapi/commit/2f232985f163d64bb58bd37276692346b6bd502b): Clarify payload validation rules. Closes #2722
- [15d2cc7](https://github.com/hapijs/hapi/commit/15d2cc73de12b9e4fdf191564179997862a2a968): after() cleanup. Closes #2815
- [79baeb0](https://github.com/hapijs/hapi/commit/79baeb0f10bae39899621741b1f32d7ab5028662): Load plugin once. Closes #2761. Closes #2797
- [b947135](https://github.com/hapijs/hapi/commit/b9471359dc34265a81c0a6b32316ce53f21165e6): Assert when adding after() after init. Closes #2812
- [e0d66e8](https://github.com/hapijs/hapi/commit/e0d66e80de3f817675c682ff6efad80e4d252d3b): expose plugin registration. Closes #2777
- [c34a556](https://github.com/hapijs/hapi/commit/c34a556216d7433c961028bd650cc6606a183ba8): CORS merge mode. Closes #2733

There are 154 commits in total. See the [full diff](https://github.com/hapijs/hapi/compare/bc722ef68407c398178e72b104c4ee7e8eb4c696...fc2f49de5895963af494d5fa3a3f7010ffb294b5).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
